### PR TITLE
Wrong/missing Exception 

### DIFF
--- a/src/administrator/components/com_ccm/src/Model/MigrationModel.php
+++ b/src/administrator/components/com_ccm/src/Model/MigrationModel.php
@@ -408,7 +408,7 @@ class MigrationModel extends FormModel
                                         $value = $mapping[1];
                                     }
                                 } else {
-                                    throw new Exception("No menutype mapping found for menu_id $oldMenuId");
+                                    throw new \RuntimeException("No menutype mapping found for menu_id $oldMenuId");
                                 }
                                 break;
                         }


### PR DESCRIPTION

### Summary of Changes

Fix Exception
Exception -> \Run
### Testing Instructions
Running a Joomla to Joomla Migration
An error has occurred.
0 Class "Joomla\Component\CCM\Administrator\Model\Exception" not found
(No menutype mapping found for menu_id)

### Documentation Changes Required
